### PR TITLE
Convert project modules to CommonJS

### DIFF
--- a/Crypto/TuyaCommandEncryptor.js
+++ b/Crypto/TuyaCommandEncryptor.js
@@ -123,4 +123,4 @@ class TuyaCommandEncryptor {
     }
 }
 
-export default TuyaCommandEncryptor;
+module.exports = TuyaCommandEncryptor;

--- a/DeviceList.js
+++ b/DeviceList.js
@@ -74,8 +74,3 @@ const DeviceList = {
 
 // SOLO exportar DeviceList, SIN ProductId
 module.exports = DeviceList;
-
-// Para compatibilidad con ES6
-if (typeof exports !== 'undefined') {
-    exports.default = DeviceList;
-}

--- a/TuyaController.js
+++ b/TuyaController.js
@@ -3,11 +3,11 @@
  * Basado en TuyaController.test.js del plugin FU-RAZ
  */
 
-import TuyaDeviceModel from './models/TuyaDeviceModel.js';
-import TuyaSessionNegotiator from './negotiators/TuyaSessionNegotiator.js';
-import TuyaCommandEncryptor from './crypto/TuyaCommandEncryptor.js';
-import DeviceList from './DeviceList.js';
-import udp from "@SignalRGB/udp";
+const TuyaDeviceModel = require('./models/TuyaDeviceModel.js');
+const TuyaSessionNegotiator = require('./negotiators/TuyaSessionNegotiator.js');
+const TuyaCommandEncryptor = require('./crypto/TuyaCommandEncryptor.js');
+const DeviceList = require('./DeviceList.js');
+const udp = require('@SignalRGB/udp');
 
 class TuyaController {
     constructor(device) {
@@ -232,4 +232,4 @@ class TuyaController {
     }
 }
 
-export default TuyaController;
+module.exports = TuyaController;

--- a/comms/Discovery.js
+++ b/comms/Discovery.js
@@ -2,7 +2,7 @@
  * Servicio de descubrimiento de dispositivos Tuya
  */
 
-import udp from "@SignalRGB/udp";
+const udp = require('@SignalRGB/udp');
 const EventEmitter = require('../utils/EventEmitter.js');
 
 class TuyaDiscovery extends EventEmitter {
@@ -191,8 +191,3 @@ class TuyaDiscovery extends EventEmitter {
 }
 
 module.exports = TuyaDiscovery;
-
-// Para compatibilidad con ES6
-if (typeof exports !== 'undefined') {
-    exports.default = TuyaDiscovery;
-}

--- a/models/TuyaDeviceModel.js
+++ b/models/TuyaDeviceModel.js
@@ -112,8 +112,3 @@ class TuyaDeviceModel {
 
 // SOLO exportar la clase, SIN ProductId
 module.exports = TuyaDeviceModel;
-
-// Para compatibilidad con ES6
-if (typeof exports !== 'undefined') {
-    exports.default = TuyaDeviceModel;
-}

--- a/negotiators/TuyaSessionNegotiator.js
+++ b/negotiators/TuyaSessionNegotiator.js
@@ -207,8 +207,3 @@ class TuyaSessionNegotiator extends EventEmitter {
 }
 
 module.exports = TuyaSessionNegotiator;
-
-// Para compatibilidad con ES6
-if (typeof exports !== 'undefined') {
-    exports.default = TuyaSessionNegotiator;
-}

--- a/ui/service.js
+++ b/ui/service.js
@@ -22,8 +22,6 @@ const ServiceHelper = {
 };
 
 // Exportar para uso si es necesario
-export default ServiceHelper;
-
 if (typeof module !== 'undefined' && module.exports) {
     module.exports = ServiceHelper;
 }


### PR DESCRIPTION
## Summary
- migrate modules to CommonJS style
- remove ES module export helpers

## Testing
- `node -c TuyaController.js`
- `node -c comms/Discovery.js`
- `node -c models/TuyaDeviceModel.js`
- `node -c DeviceList.js`
- `node -c negotiators/TuyaSessionNegotiator.js`
- `node -c ui/service.js`
- `node -c Crypto/TuyaCommandEncryptor.js`


------
https://chatgpt.com/codex/tasks/task_e_68424503a8e883228535862affb8d44a