### PR TITLE
Fix UDP fallback and module path

### DIFF
--- a/TuyaController.js
+++ b/TuyaController.js
@@ -5,9 +5,14 @@
 
 const TuyaDeviceModel = require('./models/TuyaDeviceModel.js');
 const TuyaSessionNegotiator = require('./negotiators/TuyaSessionNegotiator.js');
-const TuyaCommandEncryptor = require('./crypto/TuyaCommandEncryptor.js');
+const TuyaCommandEncryptor = require('./Crypto/TuyaCommandEncryptor.js');
 const DeviceList = require('./DeviceList.js');
-const udp = require('@SignalRGB/udp');
+let udp;
+try {
+    udp = require('@SignalRGB/udp');
+} catch (err) {
+    udp = require('dgram');
+}
 
 class TuyaController {
     constructor(device) {

--- a/comms/Discovery.js
+++ b/comms/Discovery.js
@@ -2,7 +2,14 @@
  * Servicio de descubrimiento de dispositivos Tuya
  */
 
-const udp = require('@SignalRGB/udp');
+let udp;
+try {
+    // Prefer the SignalRGB UDP module if available
+    udp = require('@SignalRGB/udp');
+} catch (err) {
+    // Fallback to Node's built in dgram implementation for development
+    udp = require('dgram');
+}
 const EventEmitter = require('../utils/EventEmitter.js');
 
 class TuyaDiscovery extends EventEmitter {


### PR DESCRIPTION
## Summary
- add fallback to Node's `dgram` when `@SignalRGB/udp` is unavailable
- correct path to `TuyaCommandEncryptor` to match directory case

## Testing
- `node index.js`

------
https://chatgpt.com/codex/tasks/task_e_68424caa60a48322988c74c19355fce4