### PR TITLE
Fix discovery export and add communication modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 - `TuyaController.js` - Controlador central para gestionar dispositivos
 - `TuyaDevice.js` - Clase que representa un dispositivo Tuya
 - `crypto.js` - Funciones para cifrado y comunicación con dispositivos Tuya
-- `comms/` - Módulos para comunicación (Discovery, TuyaProtocol)
+- `comms/` - Módulos para comunicación (`Discovery`, `TuyaUDP`, `TuyaTCP`)
 - `ui/` - Componentes de interfaz de usuario para el plugin
 
 ---

--- a/comms/Discovery.js
+++ b/comms/Discovery.js
@@ -1,5 +1,9 @@
 /**
- * Servicio de descubrimiento de dispositivos Tuya
+ * Servicio de descubrimiento de dispositivos Tuya.
+ *
+ * Maneja el envío y recepción de paquetes UDP de broadcast para localizar
+ * dispositivos en la red local. Expone métodos públicos para iniciar y
+ * detener el proceso de forma segura.
  */
 
 let udp;
@@ -194,6 +198,23 @@ class TuyaDiscovery extends EventEmitter {
     clearDevices() {
         this.devices.clear();
         this.emit('devices_cleared');
+    }
+
+    /**
+     * Alias público para iniciar el descubrimiento.
+     * Mantiene compatibilidad con versiones anteriores.
+     * @returns {Promise<void>}
+     */
+    startDiscovery() {
+        return this.start();
+    }
+
+    /**
+     * Alias público para detener el descubrimiento.
+     * @returns {Promise<void>}
+     */
+    stopDiscovery() {
+        return this.stop();
     }
 }
 

--- a/comms/TuyaTCP.js
+++ b/comms/TuyaTCP.js
@@ -1,0 +1,61 @@
+/**
+ * TuyaTCP.js
+ * Abstracción sencilla para conexiones TCP con dispositivos Tuya.
+ * Permite establecer la conexión, enviar datos y cerrar el socket.
+ */
+
+const net = require('net');
+
+class TuyaTCP {
+    constructor(host, port = 6668) {
+        this.host = host;
+        this.port = port;
+        this.socket = null;
+    }
+
+    /**
+     * Abre una conexión TCP con el dispositivo.
+     * @returns {Promise<void>}
+     */
+    connect() {
+        return new Promise((resolve, reject) => {
+            this.socket = net.createConnection(this.port, this.host, resolve);
+            this.socket.once('error', err => {
+                reject(err);
+            });
+        });
+    }
+
+    /**
+     * Envía datos por la conexión abierta.
+     * @param {Buffer|string} data - Datos a enviar
+     * @returns {Promise<void>}
+     */
+    send(data) {
+        return new Promise((resolve, reject) => {
+            if (!this.socket) {
+                return reject(new Error('Socket not connected'));
+            }
+            const buffer = Buffer.isBuffer(data) ? data : Buffer.from(data);
+            this.socket.write(buffer, err => {
+                if (err) reject(err); else resolve();
+            });
+        });
+    }
+
+    /**
+     * Cierra la conexión TCP.
+     */
+    close() {
+        if (this.socket) {
+            try {
+                this.socket.end();
+            } catch (err) {
+                // TODO: manejar errores de cierre
+            }
+            this.socket = null;
+        }
+    }
+}
+
+module.exports = TuyaTCP;

--- a/comms/TuyaUDP.js
+++ b/comms/TuyaUDP.js
@@ -1,0 +1,51 @@
+/**
+ * TuyaUDP.js
+ * Proporciona utilidades básicas para el envío de paquetes UDP.
+ * Usa el módulo UDP de SignalRGB si está disponible y cae a dgram
+ * en entornos de desarrollo.
+ */
+
+let dgram;
+try {
+    dgram = require('@SignalRGB/udp');
+} catch (err) {
+    dgram = require('dgram');
+}
+
+class TuyaUDP {
+    constructor() {
+        this.socket = dgram.createSocket('udp4');
+    }
+
+    /**
+     * Envía un mensaje UDP.
+     * @param {Buffer|string} msg - Datos a enviar
+     * @param {number} port - Puerto destino
+     * @param {string} host - Host destino
+     * @returns {Promise<void>}
+     */
+    send(msg, port, host) {
+        return new Promise((resolve, reject) => {
+            const buffer = Buffer.isBuffer(msg) ? msg : Buffer.from(msg);
+            this.socket.send(buffer, port, host, err => {
+                if (err) reject(err); else resolve();
+            });
+        });
+    }
+
+    /**
+     * Cierra el socket UDP.
+     */
+    close() {
+        if (this.socket) {
+            try {
+                this.socket.close();
+            } catch (err) {
+                // TODO: manejar errores específicos de cierre
+            }
+            this.socket = null;
+        }
+    }
+}
+
+module.exports = TuyaUDP;

--- a/test/DeviceList.test.js
+++ b/test/DeviceList.test.js
@@ -1,0 +1,10 @@
+const assert = require('assert');
+const DeviceList = require('../DeviceList');
+
+(() => {
+    const types = DeviceList.getDeviceTypes();
+    assert.ok(Array.isArray(types), 'Device types should be array');
+    const ledStrip = DeviceList.getDeviceTypeConfig('LED Strip');
+    assert.ok(ledStrip.defaultLeds > 0, 'Config should have default leds');
+    console.log('DeviceList tests passed');
+})();

--- a/test/Discovery.test.js
+++ b/test/Discovery.test.js
@@ -1,0 +1,12 @@
+const assert = require('assert');
+const TuyaDiscovery = require('../comms/Discovery.js');
+
+(async () => {
+    const discovery = new TuyaDiscovery({ port: 0 });
+    assert.strictEqual(typeof discovery.startDiscovery, 'function', 'startDiscovery missing');
+    await discovery.startDiscovery();
+    assert.ok(discovery.isRunning, 'discovery should be running');
+    await discovery.stopDiscovery();
+    assert.ok(!discovery.isRunning, 'discovery should be stopped');
+    console.log('Discovery tests passed');
+})();

--- a/test/TuyaController.test.js
+++ b/test/TuyaController.test.js
@@ -1,0 +1,10 @@
+const assert = require('assert');
+const TuyaController = require('../TuyaController');
+const TuyaDeviceModel = require('../models/TuyaDeviceModel');
+
+(() => {
+    const device = new TuyaDeviceModel({ id: '1', ip: '127.0.0.1', key: '1234' });
+    const ctrl = new TuyaController(device);
+    assert.ok(ctrl.device instanceof TuyaDeviceModel, 'controller has device');
+    console.log('TuyaController tests passed');
+})();

--- a/test/TuyaDevice.test.js
+++ b/test/TuyaDevice.test.js
@@ -1,0 +1,10 @@
+const assert = require('assert');
+const TuyaDevice = require('../TuyaDevice');
+
+(() => {
+    const dev = new TuyaDevice({ id: '1', ip: '127.0.0.1', key: '1234' });
+    dev.setLedCount(10).then(() => {
+        assert.strictEqual(dev.ledCount, 10);
+        console.log('TuyaDevice tests passed');
+    });
+})();

--- a/test/TuyaTCP.test.js
+++ b/test/TuyaTCP.test.js
@@ -1,0 +1,19 @@
+const net = require('net');
+const assert = require('assert');
+const TuyaTCP = require('../comms/TuyaTCP');
+
+(async () => {
+    // create simple echo server
+    const server = net.createServer(sock => {
+        sock.on('data', d => sock.write(d));
+    });
+    await new Promise(r => server.listen(0, r));
+    const port = server.address().port;
+
+    const client = new TuyaTCP('127.0.0.1', port);
+    await client.connect();
+    await client.send('ping');
+    client.close();
+    server.close();
+    console.log('TuyaTCP tests passed');
+})();

--- a/test/TuyaUDP.test.js
+++ b/test/TuyaUDP.test.js
@@ -1,0 +1,10 @@
+const TuyaUDP = require('../comms/TuyaUDP');
+const assert = require('assert');
+
+(async () => {
+    const udp = new TuyaUDP();
+    assert.ok(udp.socket, 'socket should exist');
+    await udp.send('test', 41234, '127.0.0.1').catch(() => {});
+    udp.close();
+    console.log('TuyaUDP tests passed');
+})();

--- a/test/runTests.js
+++ b/test/runTests.js
@@ -1,0 +1,9 @@
+const fs = require('fs');
+const path = require('path');
+
+const testFiles = fs.readdirSync(__dirname).filter(f => f.endsWith('.test.js'));
+(async () => {
+    for (const file of testFiles) {
+        require(path.join(__dirname, file));
+    }
+})();


### PR DESCRIPTION
## Summary
- document discovery class
- add `startDiscovery()` and `stopDiscovery()` convenience methods
- create `TuyaUDP` and `TuyaTCP` helpers
- update README to reflect new modules
- add simple manual tests for main modules

## Testing
- `node test/runTests.js`

------
https://chatgpt.com/codex/tasks/task_e_684258c842bc8322aaee66548cf015d3