### PR TITLE
Fix service init from QML

### DIFF
--- a/ui/TuyaUI.qml
+++ b/ui/TuyaUI.qml
@@ -46,6 +46,15 @@ Item {
         onTriggered: statusMessage = ""
     }
 
+    // Indicador sencillo para saber que el UI se cargó
+    Text {
+        id: uiLoadedLabel
+        text: "UI cargada"
+        anchors.top: parent.top
+        anchors.horizontalCenter: parent.horizontalCenter
+        color: "#ff0000"
+    }
+
     ScrollView {
         anchors.fill: parent
         anchors.margins: 20
@@ -438,8 +447,12 @@ Item {
     }
 
     Component.onCompleted: {
+        // Inicializar el puente con el backend si está disponible
+        if (service && typeof service.initialize === "function") {
+            service.initialize();
+        }
         // Cargar dispositivos al iniciar
-        if (service) {
+        if (service && typeof service.getDevices === "function") {
             devices = service.getDevices();
         }
     }


### PR DESCRIPTION
## Summary
- display a visible label so the QML UI shows it loaded
- initialize the backend from `Component.onCompleted` in `TuyaUI.qml`

## Testing
- `node test/runTests.js`

------
https://chatgpt.com/codex/tasks/task_e_6842e0f416bc832285bfc7740ad647b0