### PR TITLE
Add verbose device state logging

### DIFF
--- a/TuyaController.js
+++ b/TuyaController.js
@@ -44,6 +44,7 @@ class TuyaController {
             
             // Guardar configuración
             const saved = this.device.saveSettings();
+            service.log(`Estado actualizado: enabled=${this.device.enabled}, localKey=${this.device.localKey}`);
             
             if (saved) {
                 service.log('Device configuration updated: ' + this.device.id);

--- a/index.js
+++ b/index.js
@@ -290,6 +290,7 @@ class DiscoveryService {
                     service.log('DiscoveryService: failed to initialize TuyaDeviceModel');
                     return;
                 }
+                service.log(`Estado del dispositivo: enabled=${newDeviceModel.enabled}, localKey=${newDeviceModel.localKey}`);
 
                 const newController = new TuyaController(newDeviceModel);
                 controllers.push(newController);
@@ -391,6 +392,7 @@ function loadSavedDevices() {
                     }
                     const controller = new TuyaController(deviceModel);
                     controllers.push(controller);
+                    service.log(`Loaded device ${deviceModel.id}: enabled=${deviceModel.enabled}, localKey=${deviceModel.localKey}`);
                     loadedCount++;
                     if (!deviceModel.localKey) {
                         service.log('Warning: no localKey stored for ' + deviceModel.id);

--- a/models/TuyaDeviceModel.js
+++ b/models/TuyaDeviceModel.js
@@ -53,7 +53,7 @@ class TuyaDeviceModel {
             // Usar servicio global si está disponible
             if (typeof service !== 'undefined') {
                 service.saveSetting(this.id, 'configData', JSON.stringify(config));
-                service.log('Settings saved for device: ' + this.id);
+                service.log(`Settings saved for device: ${this.id} (enabled=${this.enabled}, localKey=${this.localKey})`);
             }
             return true;
         } catch (error) {
@@ -75,7 +75,7 @@ class TuyaDeviceModel {
                     this.localKey = config.localKey;
                     this.enabled = config.enabled || false;
                     this.deviceType = config.deviceType || 'LED Strip';
-                    service.log('Settings loaded for device: ' + this.id);
+                    service.log(`Settings loaded for device: ${this.id} (enabled=${this.enabled}, localKey=${this.localKey})`);
                     return true;
                 }
             }


### PR DESCRIPTION
## Summary
- add verbose logs when saving and loading device settings
- log device state when new devices are discovered or loaded
- show current enabled/localKey after configuration updates

## Testing
- `node test/runTests.js`

------
https://chatgpt.com/codex/tasks/task_e_68430a17bab88322be6f3a5a86412084