### PR TITLE
Ignore enabled flag for tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -299,7 +299,8 @@ class DiscoveryService {
                     try {
                         service.addController(newController);
                         console.log(`✅ Controlador registrado: ${newController.device.name}`);
-                        if (newDeviceModel.enabled && typeof service.announceController === 'function') {
+                        // Temporarily announce controller regardless of enabled flag
+                        if (/* newDeviceModel.enabled && */ typeof service.announceController === 'function') {
                             service.announceController(newController);
                         }
                     } catch (addErr) {
@@ -321,7 +322,8 @@ class DiscoveryService {
                 service.log('New device added to controllers list: ' + newDeviceModel.id);
                 saveDeviceList();
 
-                if (newDeviceModel.localKey && newDeviceModel.enabled) {
+                // Temporarily start negotiation regardless of LocalKey/Enabled state
+                if (/* newDeviceModel.localKey && newDeviceModel.enabled */ true) {
                     service.log(`Attempting negotiation for new device: ${newDeviceModel.id}`);
                     newController.startNegotiation();
                 } else {


### PR DESCRIPTION
## Summary
- temporarily ignore the `enabled` preference when announcing controllers
- start negotiation regardless of local key or enabled flag

## Testing
- `node test/runTests.js`

------
https://chatgpt.com/codex/tasks/task_e_68430b27450c8322a7b5d6f18c6997a4