### PR TITLE
Initialize discovery on UI load

### DIFF
--- a/TuyaUI.qml
+++ b/TuyaUI.qml
@@ -452,6 +452,12 @@ Item {
         if (service && typeof service.initialize === "function") {
             service.initialize();
         }
+
+        // Iniciar búsqueda automática si está disponible
+        if (service && service.startDiscovery) {
+            service.startDiscovery();
+        }
+
         // Cargar dispositivos al iniciar
         if (service && typeof service.getDevices === "function") {
             devices = service.getDevices();

--- a/ui/TuyaUI.qml
+++ b/ui/TuyaUI.qml
@@ -452,6 +452,12 @@ Item {
         if (service && typeof service.initialize === "function") {
             service.initialize();
         }
+
+        // Iniciar búsqueda automática si está disponible
+        if (service && service.startDiscovery) {
+            service.startDiscovery();
+        }
+
         // Cargar dispositivos al iniciar
         if (service && typeof service.getDevices === "function") {
             devices = service.getDevices();


### PR DESCRIPTION
## Summary
- start device discovery automatically when the UI loads

## Testing
- `node test/runTests.js`

------
https://chatgpt.com/codex/tasks/task_e_684361482b408322986a4040f2fdb3bd