### PR TITLE
Handle service object availability before init

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ import TuyaDiscoveryServiceInternal from './comms/Discovery.js';
 import TuyaController from './TuyaController.js';
 import TuyaDeviceModel from './models/TuyaDeviceModel.js';
 import DeviceList from './DeviceList.js';
+import service from './service.js';
 
 // Optional filesystem access if available (Node environments)
 let fs;
@@ -63,14 +64,15 @@ let controllers = [];
 let globalDebugMode = false;
 let globalDiscoveryTimeout = 5000;
 
-// CORREGIR: Simplificar manejo de service
-if (typeof service === 'undefined') {
-    global.service = { log: console.log };
-}
+
 
 // --- Funciones del Ciclo de Vida del Plugin Principal ---
 
 function Initialize() {
+    if (typeof service === 'undefined' || typeof service.log !== 'function') {
+        console.log("❌ Error: 'service' no está disponible o no es válido.");
+        return;
+    }
     try {
         service.log("Initializing Tuya LED Controller Plugin v2.0.1");
         service.log("🧪 PluginUIPath = " + PluginUIPath());

--- a/service.js
+++ b/service.js
@@ -1,0 +1,12 @@
+// service.js - bridge between QML interface and plugin backend
+// SignalRGB loads this file to expose the global `service` object.
+// When running outside of SignalRGB we provide a minimal stub.
+
+const svc = (typeof global !== 'undefined' && global.service) ? global.service : {};
+
+if (typeof global !== 'undefined') {
+    global.service = svc;
+}
+
+export default svc;
+


### PR DESCRIPTION
## Summary
- add a minimal `service.js` bridge so SignalRGB can populate `service`
- import this new module in `index.js`
- validate the `service` object at the start of `Initialize()`

## Testing
- `node test/runTests.js`

------
https://chatgpt.com/codex/tasks/task_e_684367dc06c883229481b29deb83a238