### PR TITLE
Enhance service logging and diagnostics

### DIFF
--- a/service.js
+++ b/service.js
@@ -10,9 +10,21 @@ import EventEmitter from './utils/EventEmitter.js';
 const existing = (typeof global !== 'undefined' && global.service) ? global.service : null;
 
 // Basic service implementation using the simplified EventEmitter
-class Service extends EventEmitter {}
+class Service extends EventEmitter {
+    emit(event, ...args) {
+        if (this._eventHistory) {
+            this._eventHistory.push({ event, args, ts: Date.now() });
+        }
+        return super.emit(event, ...args);
+    }
+}
 
 const svc = existing || new Service();
+
+// Mark when running in test/development mode
+if (!existing) {
+    console.log('[Service] Initialized in test mode'); // log early before logger
+}
 
 // -------------------------------------------------------------
 // Provide default implementations for methods used throughout the
@@ -20,11 +32,45 @@ const svc = existing || new Service();
 // -------------------------------------------------------------
 
 if (typeof svc.log !== 'function') {
-    svc.log = (...args) => console.log('[Service]', ...args);
+    svc.logLevel = 'debug';
+    const logFn = (lvl, ...msg) => {
+        const levels = { debug: 0, info: 1, warn: 2, error: 3 };
+        const cur = levels[svc.logLevel] ?? 0;
+        const lvlIndex = levels[lvl] ?? 1;
+        if (lvlIndex < cur) return;
+        const prefix = `[${lvl.toUpperCase()}]`;
+        switch (lvl) {
+        case 'error':
+            console.error(prefix, ...msg);
+            break;
+        case 'warn':
+            console.warn(prefix, ...msg);
+            break;
+        case 'debug':
+            console.debug(prefix, ...msg);
+            break;
+        default:
+            console.log(prefix, ...msg);
+        }
+    };
+    svc.log = (level, ...rest) => {
+        if (typeof level === 'string' && ['debug','info','warn','error'].includes(level)) {
+            logFn(level, ...rest);
+        } else {
+            logFn('info', level, ...rest);
+        }
+    };
+    ['debug','info','warn','error'].forEach(l => {
+        svc[l] = (...a) => svc.log(l, ...a);
+    });
+    if (!existing) {
+        svc.debug('Service running in test mode');
+    }
 }
 
 // Simple in-memory settings store for development/testing
 svc._settings = svc._settings || {};
+svc._eventHistory = svc._eventHistory || [];
 
 if (typeof svc.getSetting !== 'function') {
     svc.getSetting = (section, key, def = '') => {
@@ -35,6 +81,7 @@ if (typeof svc.getSetting !== 'function') {
 
 if (typeof svc.saveSetting !== 'function') {
     svc.saveSetting = (section, key, value) => {
+        if (typeof section !== 'string' || typeof key !== 'string') return;
         if (!svc._settings[section]) svc._settings[section] = {};
         svc._settings[section][key] = value;
     };
@@ -44,14 +91,33 @@ if (typeof svc.saveSetting !== 'function') {
 ['deviceConfigured', 'deviceError', 'negotiationComplete',
  'discoveryComplete', 'controllersChanged', 'addController',
  'announceController', 'deviceDiscovered'].forEach(fn => {
-    if (typeof svc[fn] !== 'function') {
-        svc[fn] = () => {};
-    }
+    let original = typeof svc[fn] === 'function' ? svc[fn] : null;
+    const wrapper = (...a) => {
+        svc.emit(fn, ...a);
+        if (original) return original.apply(svc, a);
+    };
+    Object.defineProperty(svc, fn, {
+        configurable: true,
+        enumerable: true,
+        get() { return wrapper; },
+        set(fnVal) { original = (typeof fnVal === 'function') ? fnVal : null; }
+    });
 });
 
 if (typeof svc.controllers === 'undefined') {
     svc.controllers = [];
 }
+
+svc.getEventHistory = () => [...svc._eventHistory];
+
+svc.getStatusReport = () => {
+    return {
+        controllers: svc.controllers.length,
+        initialized: !!svc.controllersChanged,
+        readyForAnnounce: typeof svc.announceController === 'function',
+        settingsStored: Object.keys(svc._settings).length
+    };
+};
 
 if (typeof global !== 'undefined') {
     global.service = svc;


### PR DESCRIPTION
## Summary
- improve the service stub with event history support
- add structured logging with debug/info/warn/error helpers
- validate types before saving settings
- emit controller events and expose status reports
- log when running in test mode

## Testing
- `node test/runTests.js`

------
https://chatgpt.com/codex/tasks/task_e_684372b256a483229f49f0aabdaeadbf