### PR TITLE
Fix CommonJS compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,12 +4,12 @@
  * @version 2.0.1 (Refactored based on fu-raz structure)
  */
 
-// Utilizamos importaciones ES6 para coherencia con SignalRGB
-import TuyaDiscoveryServiceInternal from './comms/Discovery.js';
-import TuyaController from './TuyaController.js';
-import TuyaDeviceModel from './models/TuyaDeviceModel.js';
-import DeviceList from './DeviceList.js';
-import service from './service.js';
+// Cargar dependencias usando CommonJS para compatibilidad con SignalRGB
+const TuyaDiscoveryServiceInternal = require('./comms/Discovery.js');
+const TuyaController = require('./TuyaController.js');
+const TuyaDeviceModel = require('./models/TuyaDeviceModel.js');
+const DeviceList = require('./DeviceList.js');
+const service = require('./service.js');
 
 // Optional filesystem access if available (Node environments)
 let fs;
@@ -437,7 +437,7 @@ function saveDeviceList() {
     }
 }
 
-export {
+module.exports = {
     Name,
     Version,
     Type,

--- a/service.js
+++ b/service.js
@@ -4,7 +4,8 @@
 // the necessary methods and event placeholders so that the QML UI
 // and backend code can interact without throwing errors.
 
-import EventEmitter from './utils/EventEmitter.js';
+// Use CommonJS to ensure compatibility with SignalRGB's module loader
+const EventEmitter = require('./utils/EventEmitter.js');
 
 // Reuse existing global service if one was provided by SignalRGB
 const existing = (typeof global !== 'undefined' && global.service) ? global.service : null;
@@ -123,5 +124,5 @@ if (typeof global !== 'undefined') {
     global.service = svc;
 }
 
-export default svc;
+module.exports = svc;
 


### PR DESCRIPTION
## Summary
- use CommonJS `require` instead of ES modules
- export plugin functions via `module.exports`

## Testing
- `node test/runTests.js`

------
https://chatgpt.com/codex/tasks/task_e_6843762e200c8322a1752bb345ae453f