### PR TITLE
Improve plugin logging

### DIFF
--- a/utils/Logger.js
+++ b/utils/Logger.js
@@ -1,1 +1,27 @@
+/**
+ * Simple color-aware logger used throughout the plugin.
+ * Provides basic log levels with a consistent prefix so logs
+ * are easy to spot in SignalRGB's console output.
+ */
+const COLOR_RESET = '\u001b[0m';
+const COLORS = {
+    debug: '\u001b[36m',   // cyan
+    info: '\u001b[32m',    // green
+    warn: '\u001b[33m',    // yellow
+    error: '\u001b[31m'    // red
+};
+
+const PREFIX = '[TuyaPlugin]';
+
+function format(level, args) {
+    const color = COLORS[level] || COLORS.info;
+    return `${color}${PREFIX}${COLOR_RESET} ${args.join(' ')}`;
+}
+
+module.exports = {
+    debug: (...a) => console.debug(format('debug', a)),
+    info: (...a) => console.log(format('info', a)),
+    warn: (...a) => console.warn(format('warn', a)),
+    error: (...a) => console.error(format('error', a))
+};
 


### PR DESCRIPTION
## Summary
- add colored Logger helper
- prefix log output for a consistent tone across the plugin
- route index.js messages through the new logger

## Testing
- `node test/runTests.js`

------
https://chatgpt.com/codex/tasks/task_e_684463a5634883228608b7dd673bcf0f