### PR TITLE
Convert project to ESM modules

### DIFF
--- a/Crypto/TuyaCommandEncryptor.js
+++ b/Crypto/TuyaCommandEncryptor.js
@@ -2,6 +2,8 @@
  * Encriptador de comandos basado en TuyaEncryptor del plugin FU-RAZ
  */
 
+import crypto from 'node:crypto';
+
 class TuyaCommandEncryptor {
     constructor(sessionKey) {
         this.sessionKey = Buffer.from(sessionKey, 'hex');
@@ -123,4 +125,5 @@ class TuyaCommandEncryptor {
     }
 }
 
-module.exports = TuyaCommandEncryptor;
+export default TuyaCommandEncryptor;
+

--- a/Crypto/lib/core.js
+++ b/Crypto/lib/core.js
@@ -185,4 +185,4 @@ CryptoJS.enc.Base64 = {
     }
 };
 
-module.exports = CryptoJS;
+export default CryptoJS;

--- a/Crypto/lib/md5.js
+++ b/Crypto/lib/md5.js
@@ -233,4 +233,4 @@ function II(a, b, c, d, x, s, t) {
 
 CryptoJS.MD5 = MD5;
 
-module.exports = CryptoJS;
+export default CryptoJS;

--- a/DeviceList.js
+++ b/DeviceList.js
@@ -74,4 +74,5 @@ const DeviceList = {
 };
 
 // SOLO exportar DeviceList, SIN ProductId
-module.exports = DeviceList;
+export default DeviceList;
+

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 
 **TUYA-ACTION-SIGNALRGB** es un plugin para [SignalRGB](https://www.signalrgb.com/) que permite descubrir, controlar y sincronizar dispositivos LED WiFi basados en Tuya desde el ecosistema SignalRGB. Compatible con tiras LED, bombillas, paneles y más.
 
+## ⚙️ Entorno totalmente ESM
+
+Todo el código está escrito utilizando la sintaxis de módulos de ECMAScript.
+El archivo `package.json` define `"type": "module"`, por lo que se
+requiere Node.js 14 o superior para ejecutar el proyecto.
+
 ---
 
 ## ⚡️ Características

--- a/TuyaController.js
+++ b/TuyaController.js
@@ -3,15 +3,16 @@
  * Basado en TuyaController.test.js del plugin FU-RAZ
  */
 
-const TuyaDeviceModel = require('./models/TuyaDeviceModel.js');
-const TuyaSessionNegotiator = require('./negotiators/TuyaSessionNegotiator.js');
-const TuyaCommandEncryptor = require('./Crypto/TuyaCommandEncryptor.js');
-const DeviceList = require('./DeviceList.js');
+import TuyaDeviceModel from './models/TuyaDeviceModel.js';
+import TuyaSessionNegotiator from './negotiators/TuyaSessionNegotiator.js';
+import TuyaCommandEncryptor from './Crypto/TuyaCommandEncryptor.js';
+import DeviceList from './DeviceList.js';
+
 let udp;
 try {
-    udp = require('@SignalRGB/udp');
+    ({ default: udp } = await import('@SignalRGB/udp'));
 } catch (err) {
-    udp = require('dgram');
+    udp = await import('node:dgram');
 }
 
 class TuyaController {
@@ -255,4 +256,5 @@ class TuyaController {
     }
 }
 
-module.exports = TuyaController;
+export default TuyaController;
+

--- a/TuyaDevice.js
+++ b/TuyaDevice.js
@@ -4,8 +4,8 @@
  */
 
 // CORREGIR: Eliminar módulos nativos no compatibles
-const EventEmitter = require('./utils/EventEmitter.js');
-const TuyaPacket = require('./utils/TuyaPacket.js'); // CORREGIR: Agregar .js
+import EventEmitter from './utils/EventEmitter.js';
+import TuyaPacket from './utils/TuyaPacket.js';
 
 class TuyaDevice extends EventEmitter {
     constructor(options) {
@@ -541,4 +541,4 @@ class TuyaDevice extends EventEmitter {
     }
 }
 
-module.exports = TuyaDevice;
+export default TuyaDevice;

--- a/comms/Discovery.js
+++ b/comms/Discovery.js
@@ -9,14 +9,14 @@
 let udp;
 try {
     // Prefer the SignalRGB UDP module if available
-    udp = require('@SignalRGB/udp');
+    ({ default: udp } = await import('@SignalRGB/udp'));
 } catch (err) {
     // Fallback to Node's built in dgram implementation for development
-    udp = require('dgram');
+    udp = await import('node:dgram');
 }
-const EventEmitter = require('../utils/EventEmitter.js');
-const crypto = require('crypto');
-const TuyaEncryption = require('../utils/TuyaEncryption.js');
+import EventEmitter from '../utils/EventEmitter.js';
+import crypto from 'node:crypto';
+import TuyaEncryption from '../utils/TuyaEncryption.js';
 const UDP_KEY = crypto.createHash('md5').update('yGAdlopoPVldABfn', 'utf8').digest();
 
 class TuyaDiscovery extends EventEmitter {
@@ -301,4 +301,5 @@ class TuyaDiscovery extends EventEmitter {
     }
 }
 
-module.exports = TuyaDiscovery;
+export default TuyaDiscovery;
+

--- a/comms/TuyaTCP.js
+++ b/comms/TuyaTCP.js
@@ -4,7 +4,7 @@
  * Permite establecer la conexión, enviar datos y cerrar el socket.
  */
 
-const net = require('net');
+import net from 'node:net';
 
 class TuyaTCP {
     constructor(host, port = 6668) {
@@ -58,4 +58,5 @@ class TuyaTCP {
     }
 }
 
-module.exports = TuyaTCP;
+export default TuyaTCP;
+

--- a/comms/TuyaUDP.js
+++ b/comms/TuyaUDP.js
@@ -7,9 +7,9 @@
 
 let dgram;
 try {
-    dgram = require('@SignalRGB/udp');
+    ({ default: dgram } = await import('@SignalRGB/udp'));
 } catch (err) {
-    dgram = require('dgram');
+    dgram = await import('node:dgram');
 }
 
 class TuyaUDP {
@@ -48,4 +48,5 @@ class TuyaUDP {
     }
 }
 
-module.exports = TuyaUDP;
+export default TuyaUDP;
+

--- a/crypto.js
+++ b/crypto.js
@@ -3,7 +3,7 @@
  */
 
 // Funciones básicas para el descubrimiento y comunicación Tuya
-const crypto = require('crypto');
+import crypto from 'node:crypto';
 
 // Crear paquete de descubrimiento Tuya (para broadcast UDP)
 function createDiscoveryPacket() {
@@ -65,9 +65,10 @@ function parseSetColorResponse(msg) {
 }
 
 // Exportar funciones
-module.exports = {
+export {
     createDiscoveryPacket,
     parseDiscoveryResponse,
     createSetColorPacket,
     parseSetColorResponse
 };
+

--- a/index.js
+++ b/index.js
@@ -12,14 +12,10 @@ import TuyaDeviceModel from './models/TuyaDeviceModel.js';
 import DeviceList from './DeviceList.js';
 import service from './service.js';
 
-import { createRequire } from 'module';
-const require = createRequire(import.meta.url);
-// Cargar dependencias de CommonJS usando createRequire
-// Logger aplica color y prefijo a cada mensaje para dar "tonalidad" uniforme al plugin
-const logger = require('./utils/Logger.js');
+import logger from './utils/Logger.js';
 let fs;
 try {
-    fs = require('fs');
+    ({ default: fs } = await import('node:fs'));
 } catch (e) {
     fs = undefined;
 }

--- a/models/TuyaDeviceModel.js
+++ b/models/TuyaDeviceModel.js
@@ -111,4 +111,5 @@ class TuyaDeviceModel {
 }
 
 // SOLO exportar la clase, SIN ProductId
-module.exports = TuyaDeviceModel;
+export default TuyaDeviceModel;
+

--- a/negotiators/TuyaSessionNegotiator.js
+++ b/negotiators/TuyaSessionNegotiator.js
@@ -2,10 +2,10 @@
  * Manejador de negociación de sesión para protocolo Tuya v3.5
  */
 
-const EventEmitter = require('../utils/EventEmitter.js');
-const dgram = require('dgram');
-const crypto = require('crypto');
-const TuyaEncryption = require('../utils/TuyaEncryption.js');
+import EventEmitter from '../utils/EventEmitter.js';
+import dgram from 'node:dgram';
+import crypto from 'node:crypto';
+import TuyaEncryption from '../utils/TuyaEncryption.js';
 const UDP_KEY = crypto.createHash('md5').update('yGAdlopoPVldABfn', 'utf8').digest();
 
 class TuyaSessionNegotiator extends EventEmitter {
@@ -250,4 +250,5 @@ class TuyaSessionNegotiator extends EventEmitter {
     }
 }
 
-module.exports = TuyaSessionNegotiator;
+export default TuyaSessionNegotiator;
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "tuya-action-signalrgb",
+  "version": "1.0.0",
+  "type": "module"
+}

--- a/service.js
+++ b/service.js
@@ -6,8 +6,7 @@
 
 'use strict';
 
-// Use CommonJS to ensure compatibility with SignalRGB's module loader
-const EventEmitter = require('./utils/EventEmitter.js');
+import EventEmitter from './utils/EventEmitter.js';
 
 // Reuse existing global service if one was provided by SignalRGB
 const existing = (typeof global !== 'undefined' && global.service) ? global.service : null;
@@ -126,5 +125,6 @@ if (typeof global !== 'undefined') {
     global.service = svc;
 }
 
-module.exports = svc;
+export default svc;
+
 

--- a/test/DeviceList.test.js
+++ b/test/DeviceList.test.js
@@ -1,5 +1,5 @@
-const assert = require('assert');
-const DeviceList = require('../DeviceList');
+import assert from 'node:assert';
+import DeviceList from '../DeviceList.js';
 
 (() => {
     const types = DeviceList.getDeviceTypes();
@@ -8,3 +8,4 @@ const DeviceList = require('../DeviceList');
     assert.ok(ledStrip.defaultLeds > 0, 'Config should have default leds');
     console.log('DeviceList tests passed');
 })();
+

--- a/test/Discovery.test.js
+++ b/test/Discovery.test.js
@@ -1,5 +1,5 @@
-const assert = require('assert');
-const TuyaDiscovery = require('../comms/Discovery.js');
+import assert from 'node:assert';
+import TuyaDiscovery from '../comms/Discovery.js';
 
 (async () => {
     const discovery = new TuyaDiscovery({ port: 0 });
@@ -10,3 +10,4 @@ const TuyaDiscovery = require('../comms/Discovery.js');
     assert.ok(!discovery.isRunning, 'discovery should be stopped');
     console.log('Discovery tests passed');
 })();
+

--- a/test/TuyaController.test.js
+++ b/test/TuyaController.test.js
@@ -1,6 +1,6 @@
-const assert = require('assert');
-const TuyaController = require('../TuyaController');
-const TuyaDeviceModel = require('../models/TuyaDeviceModel');
+import assert from 'node:assert';
+import TuyaController from '../TuyaController.js';
+import TuyaDeviceModel from '../models/TuyaDeviceModel.js';
 
 (() => {
     const device = new TuyaDeviceModel({ id: '1', ip: '127.0.0.1', key: '1234' });
@@ -8,3 +8,4 @@ const TuyaDeviceModel = require('../models/TuyaDeviceModel');
     assert.ok(ctrl.device instanceof TuyaDeviceModel, 'controller has device');
     console.log('TuyaController tests passed');
 })();
+

--- a/test/TuyaDevice.test.js
+++ b/test/TuyaDevice.test.js
@@ -1,5 +1,5 @@
-const assert = require('assert');
-const TuyaDevice = require('../TuyaDevice');
+import assert from 'node:assert';
+import TuyaDevice from '../TuyaDevice.js';
 
 (() => {
     const dev = new TuyaDevice({ id: '1', ip: '127.0.0.1', key: '1234' });
@@ -8,3 +8,4 @@ const TuyaDevice = require('../TuyaDevice');
         console.log('TuyaDevice tests passed');
     });
 })();
+

--- a/test/TuyaTCP.test.js
+++ b/test/TuyaTCP.test.js
@@ -1,6 +1,6 @@
-const net = require('net');
-const assert = require('assert');
-const TuyaTCP = require('../comms/TuyaTCP');
+import net from 'node:net';
+import assert from 'node:assert';
+import TuyaTCP from '../comms/TuyaTCP.js';
 
 (async () => {
     // create simple echo server
@@ -17,3 +17,4 @@ const TuyaTCP = require('../comms/TuyaTCP');
     server.close();
     console.log('TuyaTCP tests passed');
 })();
+

--- a/test/TuyaUDP.test.js
+++ b/test/TuyaUDP.test.js
@@ -1,5 +1,5 @@
-const TuyaUDP = require('../comms/TuyaUDP');
-const assert = require('assert');
+import TuyaUDP from '../comms/TuyaUDP.js';
+import assert from 'node:assert';
 
 (async () => {
     const udp = new TuyaUDP();
@@ -8,3 +8,4 @@ const assert = require('assert');
     udp.close();
     console.log('TuyaUDP tests passed');
 })();
+

--- a/test/runTests.js
+++ b/test/runTests.js
@@ -1,9 +1,10 @@
-const fs = require('fs');
-const path = require('path');
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const testFiles = fs.readdirSync(__dirname).filter(f => f.endsWith('.test.js'));
-(async () => {
-    for (const file of testFiles) {
-        require(path.join(__dirname, file));
-    }
-})();
+
+for (const file of testFiles) {
+  await import(path.join(__dirname, file));
+}

--- a/utils/EventEmitter.js
+++ b/utils/EventEmitter.js
@@ -160,4 +160,4 @@ class EventEmitter {
     }
 }
 
-module.exports = EventEmitter;
+export default EventEmitter;

--- a/utils/Logger.js
+++ b/utils/Logger.js
@@ -18,7 +18,7 @@ function format(level, args) {
     return `${color}${PREFIX}${COLOR_RESET} ${args.join(' ')}`;
 }
 
-module.exports = {
+export default {
     debug: (...a) => console.debug(format('debug', a)),
     info: (...a) => console.log(format('info', a)),
     warn: (...a) => console.warn(format('warn', a)),

--- a/utils/TuyaEncryption.js
+++ b/utils/TuyaEncryption.js
@@ -3,7 +3,7 @@
  * Utilidades de cifrado para el protocolo Tuya v3.5
  */
 
-const crypto = require('crypto');
+import crypto from 'node:crypto';
 
 const TuyaEncryption = {
     /**
@@ -160,4 +160,5 @@ const TuyaEncryption = {
     }
 };
 
-module.exports = TuyaEncryption;
+export default TuyaEncryption;
+

--- a/utils/TuyaPacket.js
+++ b/utils/TuyaPacket.js
@@ -234,7 +234,7 @@ class TuyaPacket {
     }
 }
 
-module.exports = TuyaPacket;
+export default TuyaPacket;
 
 /* EJEMPLO DE USO:
 


### PR DESCRIPTION
## Summary
- enable ESM by adding a package.json with `type: module`
- convert all source and test files to use `import`/`export`
- update README with ESM notes
- ensure tests run via ESM loader

## Testing
- `node test/runTests.js`

------
https://chatgpt.com/codex/tasks/task_e_6844729d5ea4832282690170967ea9cc