### PR TITLE
Busqueda automatica al iniciar plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ requiere Node.js 14 o superior para ejecutar el proyecto.
 ## ⚡️ Características
 
 - **Descubrimiento automático** de dispositivos Tuya en red local.
+- El plugin inicia la búsqueda de dispositivos en cuanto se carga.
 - Control de **color RGB**, brillo y cantidad de LEDs.
 - Interfaz de usuario visual en QML (ajusta color, número de LEDs, estado en vivo).
 - Soporte tanto para **protocolo Tuya 3.3 como 3.4+** (cifrado GCM).

--- a/index.js
+++ b/index.js
@@ -145,6 +145,15 @@ export function Initialize() {
 
         loadSavedDevices();
 
+        // Buscar dispositivos de forma automática al iniciar el plugin
+        if (typeof service.startDiscovery === 'function') {
+            try {
+                service.startDiscovery();
+            } catch (startErr) {
+                logError('Error starting discovery automatically: ' + startErr.message);
+            }
+        }
+
         logInfo("Plugin initialized successfully.");
     } catch (error) {
         logError("Error initializing plugin: " + error.message);


### PR DESCRIPTION
## Summary
- start device discovery automatically when initializing the plugin
- document auto-discovery on plugin startup

## Testing
- `node test/runTests.js`

------
https://chatgpt.com/codex/tasks/task_e_68448a05859c8322a527cb6578c69636