### PR TITLE
Auto merge DeviceList info on discovery

### DIFF
--- a/index.js
+++ b/index.js
@@ -326,6 +326,15 @@ export class DiscoveryService {
                 }
             } else {
                 logInfo(`Creating new controller for ${deviceId}`);
+                const predefined = DeviceList.predefinedDevices.find(d => d.id === deviceId);
+                if (predefined) {
+                    deviceData.key = predefined.key;
+                    deviceData.name = predefined.name;
+                    deviceData.leds = predefined.leds;
+                    deviceData.type = predefined.type;
+                    deviceData.version = predefined.version || deviceData.version;
+                    deviceData.enabled = true;
+                }
                 const newDeviceModel = new TuyaDeviceModel(deviceData);
                 if (!newDeviceModel) {
                     logError('DiscoveryService: failed to initialize TuyaDeviceModel');


### PR DESCRIPTION
## Summary
- merge data from `DeviceList.predefinedDevices` when discovering a device
- automatically enable device if info was predefined

## Testing
- `node test/runTests.js`

------
https://chatgpt.com/codex/tasks/task_e_68448cd6363483229f39521fcc717e03