### PR TITLE
Fix negotiator API mismatch

### DIFF
--- a/TuyaController.js
+++ b/TuyaController.js
@@ -114,7 +114,15 @@ class TuyaController {
                 }
             });
             
-            this.negotiator.start();
+            // Iniciar proceso de negociación de sesión
+            if (typeof this.negotiator.negotiateSession === 'function') {
+                this.negotiator.negotiateSession();
+            } else if (typeof this.negotiator.start === 'function') {
+                // Compatibilidad por si existe un método start en otras versiones
+                this.negotiator.start();
+            } else {
+                throw new Error('Negotiator instance has no start method');
+            }
             
         } catch (error) {
             service.log('Error starting negotiation: ' + error.message);

--- a/negotiators/TuyaSessionNegotiator.js
+++ b/negotiators/TuyaSessionNegotiator.js
@@ -224,6 +224,13 @@ class TuyaSessionNegotiator extends EventEmitter {
     }
 
     /**
+     * Alias de compatibilidad para iniciar la negociación
+     */
+    start() {
+        return this.negotiateSession();
+    }
+
+    /**
      * Calcula CRC simple
      */
     calculateSimpleCRC(buffer) {


### PR DESCRIPTION
## Summary
- call `negotiateSession` when starting negotiation
- add `start()` alias to negotiator for compatibility

## Testing
- `node test/runTests.js`

------
https://chatgpt.com/codex/tasks/task_e_684497424e748322b24eaaac4dc12fb4