### PR TITLE
Prompt for LocalKey before negotiation

### DIFF
--- a/index.js
+++ b/index.js
@@ -342,6 +342,7 @@ export class DiscoveryService {
                         return;
                     }
                     deviceData.localKey = entered;
+                    deviceData.enabled = true;
                 }
 
                 const newDeviceModel = new TuyaDeviceModel(deviceData);
@@ -381,8 +382,7 @@ export class DiscoveryService {
                 logInfo('New device added to controllers list: ' + newDeviceModel.id);
                 saveDeviceList();
 
-                // Temporarily start negotiation regardless of LocalKey/Enabled state
-                if (/* newDeviceModel.localKey && newDeviceModel.enabled */ true) {
+                if (newDeviceModel.localKey && newDeviceModel.enabled) {
                     logInfo(`Attempting negotiation for new device: ${newDeviceModel.id}`);
                     newController.startNegotiation();
                 } else {

--- a/utils/askKey.js
+++ b/utils/askKey.js
@@ -1,15 +1,21 @@
 import readline from 'node:readline';
 
-export function askLocalKey(deviceId) {
-    return new Promise(resolve => {
-        const rl = readline.createInterface({
-            input: process.stdin,
-            output: process.stdout
+export async function askLocalKey(deviceId) {
+    let key = null;
+    while (!key) {
+        key = await new Promise(resolve => {
+            const rl = readline.createInterface({
+                input: process.stdin,
+                output: process.stdout
+            });
+            rl.question(`Introduce la localKey para el dispositivo ${deviceId}: `, answer => {
+                rl.close();
+                resolve((answer || '').trim());
+            });
         });
-        rl.question(`Introduce la localKey para el dispositivo ${deviceId}: `, answer => {
-            rl.close();
-            const key = (answer || '').trim();
-            resolve(key || null);
-        });
-    });
+        if (!key) {
+            console.log('La localKey es obligatoria.');
+        }
+    }
+    return key;
 }


### PR DESCRIPTION
## Summary
- prompt until LocalKey is provided via terminal
- enable newly discovered devices when the key is entered
- only start negotiation once the LocalKey and enabled flag are present

## Testing
- `node test/runTests.js`

------
https://chatgpt.com/codex/tasks/task_e_6844deaf00d08322b9e30704f81ebfd2