### PR TITLE
Enhance discovery script and device list

### DIFF
--- a/DeviceList.js
+++ b/DeviceList.js
@@ -10,13 +10,6 @@ const deviceTypes = [
 // Lista de dispositivos predefinidos
 const predefinedDevices = [
     {
-        id: 'example_device_1',
-        name: 'Tira LED Escritorio',
-        key: '',
-        leds: 30,
-        type: 'LED Strip'
-    },
-    {
         id: 'bfbe7bd231444751090bsq',
         name: 'Leds habitación (Barra Battletroon 1)',
         ip: '192.168.1.131',
@@ -70,7 +63,10 @@ const DeviceList = {
     deviceTypes,
     predefinedDevices,
     getDeviceTypeConfig,
-    getDeviceTypes
+    getDeviceTypes,
+    getDevices() {
+        return predefinedDevices;
+    }
 };
 
 // SOLO exportar DeviceList, SIN ProductId

--- a/DeviceList.js
+++ b/DeviceList.js
@@ -17,7 +17,8 @@ const predefinedDevices = [
         version: '3.5',
         productKey: 'keyj3w8cmutjmwk5',
         leds: 40,
-        type: 'LED Strip'
+        type: 'LED Strip',
+        enabled: true
     },
     {
         id: 'bfbebb82be7220f985rawa',
@@ -27,7 +28,8 @@ const predefinedDevices = [
         version: '3.5',
         productKey: 'keyj3w8cmutjmwk5',
         leds: 36,
-        type: 'LED Strip'
+        type: 'LED Strip',
+        enabled: true
     },
     {
         id: 'bfde5007394a05833ahsda',
@@ -37,7 +39,8 @@ const predefinedDevices = [
         version: '3.5',
         productKey: 'keyj3w8cmutjmwk5',
         leds: 40,
-        type: 'LED Strip'
+        type: 'LED Strip',
+        enabled: true
     },
     {
         id: 'bfafad43febddb888apxbj',
@@ -47,7 +50,8 @@ const predefinedDevices = [
         version: '3.5',
         productKey: 'keyj3w8cmutjmwk5',
         leds: 72,
-        type: 'LED Strip'
+        type: 'LED Strip',
+        enabled: true
     }
 ];
 

--- a/README.md
+++ b/README.md
@@ -51,3 +51,13 @@ requiere Node.js 14 o superior para ejecutar el proyecto.
    ```bash
    git clone https://github.com/BKMEN/TUYA-ACTION-SIGNALRGB.git
    ```
+
+### Ejecución rápida del descubrimiento
+
+Se incluye un pequeño script `run.js` para probar el módulo de descubrimiento de forma independiente. Ajusta la constante `EXPECTED_DEVICES` al número de dispositivos que esperas en tu red.
+
+```bash
+node run.js
+```
+
+El script detiene automáticamente la búsqueda cuando se encuentran todos los dispositivos esperados o cuando se agota un tiempo de espera de 5 segundos.

--- a/run.js
+++ b/run.js
@@ -1,0 +1,69 @@
+import TuyaDiscovery from './comms/Discovery.js';
+import TuyaController from './TuyaController.js';
+import DeviceList from './DeviceList.js';
+
+// Configuraci\u00f3n
+const EXPECTED_DEVICES = 4; // Dispositivos esperados
+const TIMEOUT_MS = 5000;    // Tiempo m\u00e1ximo de espera
+
+// Crear instancia de descubrimiento
+const discovery = new TuyaDiscovery();
+let found = 0;
+
+// Crear controlador
+const controller = new TuyaController();
+
+// Escuchar cuando se encuentra un dispositivo
+
+discovery.on('device_found', async (device) => {
+    found += 1;
+
+    // Buscar configuraci\u00f3n local del dispositivo (con key) en DeviceList
+    const config = DeviceList.getDevices().find(d => d.id === device.id);
+    if (config && config.key) {
+        // Si hay key, fusionar con los datos descubiertos
+        const fullDevice = {
+            ...device,
+            ...config,
+            leds: config.leds || 30,
+            type: config.type || 'LED Strip',
+        };
+
+        // Agregar al controlador y conectar
+        try {
+            controller.addDevice(fullDevice);
+            await controller.connectToDevice(fullDevice.id);
+            console.log(`\ud83c\udf89 Dispositivo ${fullDevice.name} listo para usarse`);
+        } catch (err) {
+            console.error(`\u274c Error al conectar con ${fullDevice.name}:`, err.message);
+        }
+    } else {
+        console.warn(`\u26a0\ufe0f Dispositivo ${device.id} descubierto sin clave definida. Saltando...`);
+    }
+
+    stopIfNeeded();
+});
+
+// Funci\u00f3n para detener el descubrimiento si se cumplen condiciones
+function stopIfNeeded() {
+    if (found >= EXPECTED_DEVICES && discovery.isRunning) {
+        console.log(`\u2705 Se encontraron ${found} dispositivos. Deteniendo descubrimiento...`);
+        discovery.stop();
+    }
+}
+
+// Logs de control
+discovery.on('started', () => console.log('\ud83d\ude80 Descubrimiento iniciado'));
+discovery.on('stopped', () => console.log('\ud83d\ude91 Descubrimiento detenido'));
+
+// Iniciar descubrimiento
+await discovery.start();
+await discovery.sendDiscoveryRequest();
+
+// Timeout de seguridad
+setTimeout(() => {
+    if (discovery.isRunning) {
+        console.log('\u23f1\ufe0f Tiempo de espera agotado. Deteniendo descubrimiento.');
+        discovery.stop();
+    }
+}, TIMEOUT_MS);

--- a/run.js
+++ b/run.js
@@ -2,6 +2,20 @@ import TuyaDiscovery from './comms/Discovery.js';
 import TuyaController from './TuyaController.js';
 import DeviceList from './DeviceList.js';
 
+globalThis.service = globalThis.service || {
+    log: console.log,
+    deviceError: (id, msg) => console.warn(`\u274c Error [${id}]: ${msg}`),
+    deviceConfigured: (id) => console.log(`\u2705 Configurado [${id}]`),
+    negotiationComplete: (id) => console.log(`\ud83d\udd10 Negociaci\u00f3n completada [${id}]`)
+};
+
+if (typeof service.getSetting !== 'function') {
+    service.getSetting = (key, defaultValue) => {
+        console.log(`\u2699\ufe0f getSetting mock: ${key} -> ${defaultValue}`);
+        return defaultValue;
+    };
+}
+
 // Configuraci\u00f3n
 const EXPECTED_DEVICES = 4; // Dispositivos esperados
 const TIMEOUT_MS = 5000;    // Tiempo m\u00e1ximo de espera

--- a/test/TuyaController.test.js
+++ b/test/TuyaController.test.js
@@ -6,6 +6,9 @@ import TuyaDeviceModel from '../models/TuyaDeviceModel.js';
     const device = new TuyaDeviceModel({ id: '1', ip: '127.0.0.1', key: '1234' });
     const ctrl = new TuyaController(device);
     assert.ok(ctrl.device instanceof TuyaDeviceModel, 'controller has device');
+    const added = ctrl.addDevice({ id: '2', ip: '127.0.0.2', key: 'abcd' });
+    assert.ok(ctrl.devices.length === 2, 'addDevice stores device');
+    assert.ok(added instanceof TuyaDeviceModel, 'addDevice returns model');
     console.log('TuyaController tests passed');
 })();
 


### PR DESCRIPTION
## Summary
- expand predefined devices list and expose helper in `DeviceList`
- implement improved auto-connect discovery script

## Testing
- `node test/runTests.js`
- `node run.js` *(fails: send ENETUNREACH 255.255.255.255:6666)*

------
https://chatgpt.com/codex/tasks/task_e_6845f59128748322aea002bb5bc4e109