### PR TITLE
Implement UDP broadcast negotiation

### DIFF
--- a/TuyaController.js
+++ b/TuyaController.js
@@ -158,7 +158,11 @@ class TuyaController {
             this.negotiator = new TuyaSessionNegotiator({
                 deviceId: this.device.id,
                 deviceKey: this.device.localKey,
-                ip: this.device.ip
+                ip: this.device.ip,
+                // Difunde la negociación para que cualquier dispositivo responda
+                broadcastAddress: '192.168.1.255',
+                listenPort: 40001,
+                broadcastPort: 6667
             });
             
             this.negotiator.on('success', (result) => {


### PR DESCRIPTION
## Summary
- negotiate Tuya sessions by broadcasting instead of connecting to `<ip>:6669`
- allow specifying broadcast IP/port and listening port
- update controller to use broadcast negotiation

## Testing
- `node test/runTests.js`

------
https://chatgpt.com/codex/tasks/task_e_6848319c98c8832280f72b77c2ce3e21