### PR TITLE
Implement UDP routing for handshake responses

### DIFF
--- a/comms/Discovery.js
+++ b/comms/Discovery.js
@@ -58,6 +58,14 @@ class TuyaDiscovery extends EventEmitter {
                 this.socket = udp.createSocket('udp4');
                 
                 this.socket.on('message', (msg, rinfo) => {
+                    const prefix = msg.slice(0, 4);
+                    if (prefix.equals(Buffer.from([0x00, 0x00, 0x55, 0xaa]))) {
+                        const cmd = msg.readUInt32BE(8);
+                        if (cmd === 0x06) {
+                            this.emit('negotiation_packet', msg, rinfo);
+                            return;
+                        }
+                    }
                     this.handleDiscoveryMessage(msg, rinfo);
                 });
 

--- a/comms/Discovery.js
+++ b/comms/Discovery.js
@@ -58,14 +58,24 @@ class TuyaDiscovery extends EventEmitter {
                 this.socket = udp.createSocket('udp4');
                 
                 this.socket.on('message', (msg, rinfo) => {
-                    const prefix = msg.slice(0, 4);
-                    if (prefix.equals(Buffer.from([0x00, 0x00, 0x55, 0xaa]))) {
-                        const cmd = msg.readUInt32BE(8);
-                        if (cmd === 0x06) {
+                    const header = msg.toString('hex', 0, 4);
+
+                    if (header === '00006699') {
+                        // Standard GCM discovery packet
+                        this.handleDiscoveryMessage(msg, rinfo);
+                        return;
+                    }
+
+                    if (header === '000055aa') {
+                        const command = msg.readUInt32BE(8);
+                        if (command === 0x06) {
+                            // Handshake response, route to negotiator
                             this.emit('negotiation_packet', msg, rinfo);
                             return;
                         }
                     }
+
+                    // Fallback to original handler for unsupported packets
                     this.handleDiscoveryMessage(msg, rinfo);
                 });
 

--- a/index.js
+++ b/index.js
@@ -321,6 +321,14 @@ export class DiscoveryService {
                 }
             });
 
+            this.internalDiscovery.on('negotiation_packet', (msg, rinfo) => {
+                controllers.forEach(ctrl => {
+                    if (ctrl.negotiator && typeof ctrl.negotiator.processResponse === 'function') {
+                        ctrl.negotiator.processResponse(msg, rinfo);
+                    }
+                });
+            });
+
             logInfo("Tuya DiscoveryService internal components initialized.");
         } catch (e) {
             logError("Error in DiscoveryService.Initialize: " + e.message);


### PR DESCRIPTION
## Summary
- route negotiation packets in `TuyaDiscovery` and emit an event
- forward those packets to active negotiators in `DiscoveryService`
- add `processResponse` handler to `TuyaSessionNegotiator`

## Testing
- `node test/runTests.js`

------
https://chatgpt.com/codex/tasks/task_e_6848342f5d908322bdf77f84d3797359