### PR TITLE
Update negotiation protocol

### DIFF
--- a/TuyaController.js
+++ b/TuyaController.js
@@ -162,7 +162,7 @@ class TuyaController {
                 // Difunde la negociación para que cualquier dispositivo responda
                 broadcastAddress: '192.168.1.255',
                 listenPort: 40001,
-                broadcastPort: 6667
+                broadcastPort: 40001
             });
             
             this.negotiator.on('success', (result) => {


### PR DESCRIPTION
## Summary
- switch negotiation port defaults to 40001
- update discovery to parse negotiation header `00006699`
- change session negotiator to use new header and add helpers for batch mode and token generation

## Testing
- `node test/runTests.js`

------
https://chatgpt.com/codex/tasks/task_e_684895fc375083229e889ea6ff9ce9c7