### PR TITLE
Update negotiation to use Tuya v3.5

### DIFF
--- a/TuyaController.js
+++ b/TuyaController.js
@@ -162,7 +162,7 @@ class TuyaController {
                 // Difunde la negociación para que cualquier dispositivo responda
                 broadcastAddress: '192.168.1.255',
                 listenPort: 40001,
-                broadcastPort: 6667
+                broadcastPort: 40001
             });
             
             this.negotiator.on('success', (result) => {

--- a/comms/Discovery.js
+++ b/comms/Discovery.js
@@ -61,7 +61,13 @@ class TuyaDiscovery extends EventEmitter {
                     const header = msg.toString('hex', 0, 4);
 
                     if (header === '00006699') {
-                        // Standard GCM discovery packet
+                        const command = msg.readUInt32BE(8);
+                        if (command === 0x06) {
+                            // Paquete de negociación v3.5
+                            this.emit('negotiation_packet', msg, rinfo);
+                            return;
+                        }
+                        // Paquete de descubrimiento cifrado
                         this.handleDiscoveryMessage(msg, rinfo);
                         return;
                     }
@@ -69,7 +75,7 @@ class TuyaDiscovery extends EventEmitter {
                     if (header === '000055aa') {
                         const command = msg.readUInt32BE(8);
                         if (command === 0x06) {
-                            // Handshake response, route to negotiator
+                            // Handshake response (protocolo antiguo)
                             this.emit('negotiation_packet', msg, rinfo);
                             return;
                         }

--- a/negotiators/TuyaSessionNegotiator.js
+++ b/negotiators/TuyaSessionNegotiator.js
@@ -35,15 +35,15 @@ class TuyaSessionNegotiator extends EventEmitter {
         this.listenPort = options.listenPort || 40001;
         // Dirección y puerto destino para el broadcast de negociación
         this.broadcastAddress = options.broadcastAddress || '192.168.1.255';
-        this.broadcastPort = options.broadcastPort || 6667;
+        this.broadcastPort = options.broadcastPort || 40001;
         this.timeout = options.timeout || 10000;
         this.maxRetries = options.maxRetries || 3;
         this.retryInterval = options.retryInterval || 5000;
         this.debugMode = options.debugMode || false;
         this.gcmBuffer = options.gcmBuffer || gcmBuffer;
-        // Prefix y sufijo deben coincidir con el plugin original
-        this.prefix = options.prefix || '000055aa';
-        this.suffix = options.suffix || '0000aa55';
+        // Prefix y sufijo para protocolo 3.5
+        this.prefix = options.prefix || '00006699';
+        this.suffix = options.suffix || '00009966';
 
         this.sessionKey = null;
         this.sessionIV = null;


### PR DESCRIPTION
## Summary
- send negotiation messages to port **40001** instead of 6667
- use the Tuya v3.5 packet header `00006699` and tail `00009966`
- route v3.5 negotiation packets in the discovery service

## Testing
- `node test/runTests.js`

------
https://chatgpt.com/codex/tasks/task_e_6848993db6008322a4775298e89b2008